### PR TITLE
feat: 로그인 화면 적용, 다크모드 재적용

### DIFF
--- a/my_solved/android/app/build.gradle
+++ b/my_solved/android/app/build.gradle
@@ -32,7 +32,7 @@ if (keystorePropertiesFile.exists()) {
 }
 
 android {
-    compileSdkVersion 32
+    compileSdkVersion 33
     ndkVersion flutter.ndkVersion
 
     compileOptions {
@@ -50,8 +50,8 @@ android {
 
     defaultConfig {
         applicationId "com.w8385.my_solved"
-        minSdkVersion 32
-        targetSdkVersion 32
+        minSdkVersion 26
+        targetSdkVersion 33
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/my_solved/android/app/src/main/AndroidManifest.xml
+++ b/my_solved/android/app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.w8385.my_solved">
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="com.google.android.gms.permission.AD_ID" />
 
     <application
         android:label="my_solved"

--- a/my_solved/android/build.gradle
+++ b/my_solved/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.6.10'
+    ext.kotlin_version = '1.7.20'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.2'
+        classpath 'com.android.tools.build:gradle:7.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/my_solved/lib/main.dart
+++ b/my_solved/lib/main.dart
@@ -1,12 +1,17 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/services.dart';
 import 'package:my_solved/pages/login_page.dart';
+import 'package:provider/provider.dart';
+import 'package:my_solved/providers/user/user_name.dart';
 
 void main() {
-  runApp(CupertinoApp(
-    title: 'MY.SOLVED',
-    home: MyApp(),
-  ));
+  runApp(MultiProvider(
+      providers: [
+        ChangeNotifierProvider<UserName>(
+          create: (_) => UserName(),
+        ),
+      ],
+      child: MyApp()));
 }
 
 class MyApp extends StatelessWidget {

--- a/my_solved/lib/providers/user/user_name.dart
+++ b/my_solved/lib/providers/user/user_name.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/cupertino.dart';
+
+class UserName with ChangeNotifier {
+  String _name = '';
+
+  String get name => _name;
+
+  void setName(String name) {
+    _name = name;
+    notifyListeners();
+  }
+}

--- a/my_solved/lib/view_models/home_view_model.dart
+++ b/my_solved/lib/view_models/home_view_model.dart
@@ -7,11 +7,10 @@ import '../providers/user/show_api.dart';
 import '../models/user/ProblemStats.dart';
 
 class HomeViewModel with ChangeNotifier {
-  String handle = 'w8385';
   Future<User>? future;
   Future<ProblemStats>? futurePS;
 
-  void onInit() {
+  void onInit(String handle) {
     future = userShow(handle);
     futurePS = userProblemStats(handle);
     notifyListeners();

--- a/my_solved/lib/view_models/login_view_model.dart
+++ b/my_solved/lib/view_models/login_view_model.dart
@@ -1,10 +1,15 @@
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 import 'package:my_solved/pages/main_tab_page.dart';
 import 'package:my_solved/providers/user/user_name.dart';
 import 'package:provider/provider.dart';
 
+import '../models/User.dart';
+import '../providers/user/show_api.dart';
+
 class LoginViewModel with ChangeNotifier {
   String handle = '';
+  Future<User>? future;
 
   void textFieldChanged(String userName) {
     handle = userName;
@@ -12,11 +17,19 @@ class LoginViewModel with ChangeNotifier {
   }
 
   void onTapLoginButton(BuildContext context) {
-    Navigator.of(context).push(
-      CupertinoPageRoute(
-        builder: ((context) => MainTabPage()),
-      ),
-    );
     Provider.of<UserName>(context, listen: false).setName(handle);
+    future = userShow(handle);
+    future!.then((value) {
+      Navigator.push(
+        context,
+        CupertinoPageRoute(
+          builder: (context) => MainTabPage(),
+        ),
+      );
+    })
+    .catchError((error) {
+
+    });
   }
 }
+

--- a/my_solved/lib/view_models/login_view_model.dart
+++ b/my_solved/lib/view_models/login_view_model.dart
@@ -1,19 +1,22 @@
 import 'package:flutter/cupertino.dart';
-import 'package:my_solved/pages/home_page.dart';
+import 'package:my_solved/pages/main_tab_page.dart';
+import 'package:my_solved/providers/user/user_name.dart';
+import 'package:provider/provider.dart';
 
 class LoginViewModel with ChangeNotifier {
-  String text = '';
+  String handle = '';
 
-  void textFieldChanged(String value) {
-    text = value;
+  void textFieldChanged(String userName) {
+    handle = userName;
     notifyListeners();
   }
 
   void onTapLoginButton(BuildContext context) {
     Navigator.of(context).push(
       CupertinoPageRoute(
-        builder: ((context) => HomePage()),
+        builder: ((context) => MainTabPage()),
       ),
     );
+    Provider.of<UserName>(context, listen: false).setName(handle);
   }
 }

--- a/my_solved/lib/view_models/login_view_model.dart
+++ b/my_solved/lib/view_models/login_view_model.dart
@@ -21,12 +21,10 @@ class LoginViewModel with ChangeNotifier {
     Provider.of<UserName>(context, listen: false).setName(handle);
     future = userShow(handle);
     future!.then((value) {
-      Navigator.push(
+      Navigator.pushAndRemoveUntil(
         context,
-        CupertinoPageRoute(
-          builder: (context) => MainTabPage(),
-        ),
-      );
+        MaterialPageRoute(builder: (context) => MainTabPage()),
+        (route) => false);
     })
     .catchError((error) {
       return showToast();

--- a/my_solved/lib/view_models/login_view_model.dart
+++ b/my_solved/lib/view_models/login_view_model.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:fluttertoast/fluttertoast.dart';
 import 'package:my_solved/pages/main_tab_page.dart';
 import 'package:my_solved/providers/user/user_name.dart';
 import 'package:provider/provider.dart';
@@ -28,8 +29,19 @@ class LoginViewModel with ChangeNotifier {
       );
     })
     .catchError((error) {
-
+      return showToast();
     });
   }
 }
 
+void showToast() {
+  Fluttertoast.showToast(
+      msg: "로그인 실패",
+      toastLength: Toast.LENGTH_SHORT,
+      gravity: ToastGravity.BOTTOM,
+      timeInSecForIosWeb: 1,
+      backgroundColor: Colors.green,
+      textColor: Colors.white,
+      fontSize: 16.0
+  );
+}

--- a/my_solved/lib/view_models/login_view_model.dart
+++ b/my_solved/lib/view_models/login_view_model.dart
@@ -36,7 +36,7 @@ class LoginViewModel with ChangeNotifier {
 
 void showToast() {
   Fluttertoast.showToast(
-      msg: "로그인 실패",
+      msg: "존재하지 않는 닉네임입니다.",
       toastLength: Toast.LENGTH_SHORT,
       gravity: ToastGravity.BOTTOM,
       timeInSecForIosWeb: 1,

--- a/my_solved/lib/views/home_view.dart
+++ b/my_solved/lib/views/home_view.dart
@@ -4,6 +4,7 @@ import 'package:my_solved/view_models/home_view_model.dart';
 import 'package:provider/provider.dart';
 
 import '../models/User.dart';
+import '../providers/user/user_name.dart';
 import '../widgets/user_widget.dart';
 
 class HomeView extends StatelessWidget {
@@ -12,7 +13,8 @@ class HomeView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     var viewModel = Provider.of<HomeViewModel>(context);
-    viewModel.onInit();
+    String userName = Provider.of<UserName>(context).name;
+    viewModel.onInit(userName);
 
     return CupertinoPageScaffold(
       child: SafeArea(
@@ -39,14 +41,14 @@ class HomeView extends StatelessWidget {
                             ),
                             child: Column(
                               children: [
-                                handle(snapshot),
-                                organizations(snapshot),
+                                handle(context, snapshot),
+                                organizations(context, snapshot),
                                 SizedBox(height: 5),
                                 Row(
                                   children: [
-                                    solvedCount(snapshot),
+                                    solvedCount(context, snapshot),
                                     SizedBox(width: 10),
-                                    reverseRivalCount(snapshot),
+                                    reverseRivalCount(context, snapshot),
                                   ],
                                 )
                               ],
@@ -97,13 +99,13 @@ extension HomeViewExtension on HomeView {
       child: Stack(
         clipBehavior: Clip.none,
         children: <Widget>[
-          backgroundImage(snapshot),
+          backgroundImage(context, snapshot),
           Positioned(left: 15, bottom: -50, child:
             Stack(
               clipBehavior: Clip.none,
               children: <Widget>[
-                profileImage(snapshot),
-                Positioned(left: 38, top: 65, child: tiers(snapshot)),
+                profileImage(context, snapshot),
+                Positioned(left: 38, top: 65, child: tiers(context, snapshot)),
               ]
             ),
           ),

--- a/my_solved/lib/views/login_view.dart
+++ b/my_solved/lib/views/login_view.dart
@@ -20,7 +20,9 @@ class LoginView extends StatelessWidget {
                 padding: EdgeInsets.only(top: 100, left: 20, right: 20),
                 child: Text(
                   "로그인",
-                  style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+                  style: TextStyle(
+                      color: CupertinoTheme.of(context).textTheme.textStyle.color,
+                      fontSize: 24, fontWeight: FontWeight.bold),
                 ),
               ),
               Container(
@@ -32,7 +34,7 @@ class LoginView extends StatelessWidget {
               ),
               Container(
                 decoration: BoxDecoration(
-                  color: Color(0xffefeff0),
+                  color: CupertinoTheme.of(context).barBackgroundColor,
                   borderRadius: BorderRadius.circular(10),
                 ),
                 margin: EdgeInsets.only(top: 60, left: 20, right: 20),

--- a/my_solved/lib/views/login_view.dart
+++ b/my_solved/lib/views/login_view.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 import 'package:my_solved/view_models/login_view_model.dart';
 import 'package:provider/provider.dart';
 

--- a/my_solved/lib/views/login_view.dart
+++ b/my_solved/lib/views/login_view.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
 import 'package:my_solved/view_models/login_view_model.dart';
 import 'package:provider/provider.dart';
 

--- a/my_solved/lib/views/profile_detail_view.dart
+++ b/my_solved/lib/views/profile_detail_view.dart
@@ -39,14 +39,14 @@ class ProfileDetailView extends StatelessWidget {
                           Container(padding: EdgeInsets.only(left: 30), child:
                             Column(
                               children: [
-                                handle(snapshot),
-                                organizations(snapshot),
+                                handle(context, snapshot),
+                                organizations(context, snapshot),
                                 SizedBox(height: 5),
                                 Row(
                                   children: [
-                                    solvedCount(snapshot),
+                                    solvedCount(context, snapshot),
                                     SizedBox(width: 10),
-                                    reverseRivalCount(snapshot),
+                                    reverseRivalCount(context, snapshot),
                                   ],
                                 ),
                               ],
@@ -91,12 +91,12 @@ extension ProfileDetailViewExtension on ProfileDetailView {
       child: Stack(
         clipBehavior: Clip.none,
         children: <Widget>[
-          backgroundImage(snapshot),
+          backgroundImage(context, snapshot),
           Positioned(left: 25, bottom: -50, child: Stack(
               clipBehavior: Clip.none,
               children: <Widget>[
-                profileImage(snapshot),
-                Positioned(left: 38, top: 65, child: tiers(snapshot)),
+                profileImage(context, snapshot),
+                Positioned(left: 38, top: 65, child: tiers(context, snapshot)),
               ]
           ),
           ),

--- a/my_solved/lib/views/search_view.dart
+++ b/my_solved/lib/views/search_view.dart
@@ -30,7 +30,9 @@ class SearchView extends StatelessWidget {
                     child: Text(
                       '문제 검색',
                       style:
-                          TextStyle(fontWeight: FontWeight.bold, fontSize: 24),
+                          TextStyle(
+                              color: CupertinoTheme.of(context).textTheme.textStyle.color,
+                              fontWeight: FontWeight.bold, fontSize: 24),
                     ),
                   ),
                 Container(
@@ -66,7 +68,7 @@ class SearchView extends StatelessWidget {
                           child: Column(
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: <Widget>[
-                              problemHeader(),
+                              problemHeader(context),
                               for (dynamic problem in snapshot.data!.problems)
                                 problemCell(problem, context),
                               userHeader(),
@@ -94,13 +96,16 @@ class SearchView extends StatelessWidget {
 }
 
 extension SearchViewExtension on SearchView {
-  Widget problemHeader() {
+  Widget problemHeader(BuildContext context) {
     return CupertinoPageScaffold(
       child: Container(
         padding: EdgeInsets.only(top: 20),
         child: Text(
           '문제',
-          style: TextStyle(fontSize: 12, color: Color(0xff767676)),
+          style: TextStyle(
+            fontSize: 12,
+            color: Color(0xff767676)
+          ),
         ),
       ),
     );
@@ -126,7 +131,13 @@ extension SearchViewExtension on SearchView {
             children: <Widget>[
               Container(
                 padding: EdgeInsets.only(top: 20, left: 20),
-                child: Text('${problem['id']}번'),
+                child: Text(
+                  '${problem['id']}번',
+                  style: TextStyle(
+                    fontSize: 16,
+                    color: CupertinoTheme.of(context).textTheme.textStyle.color,
+                  ),
+                ),
               ),
               Container(
                 padding: EdgeInsets.only(
@@ -145,7 +156,10 @@ extension SearchViewExtension on SearchView {
                     ),
                     Text(
                       '${problem['title']}',
-                      style: TextStyle(fontSize: 22),
+                      style: TextStyle(
+                          fontSize: 20,
+                          color: CupertinoTheme.of(context).textTheme.textStyle.color
+                      ),
                     ),
                   ],
                 )
@@ -228,7 +242,7 @@ extension SearchViewExtension on SearchView {
                 SizedBox(
                   width: 10,
                 ),
-                Text('${user['handle']}'),
+                Text('${user['handle']}', style: TextStyle(color: CupertinoTheme.of(context).textTheme.textStyle.color)),
               ],
             )
           ),
@@ -271,7 +285,11 @@ extension SearchViewExtension on SearchView {
               left: 20,
               right: 20,
             ),
-            child: Text('${tag['key']} : ${tag['description']}'),
+            child: Text(
+                '${tag['key']} : ${tag['description']}',
+                style: TextStyle(
+                    color: CupertinoTheme.of(context).textTheme.textStyle.color)
+            ),
           ),
         ),
       )

--- a/my_solved/lib/views/setting_view.dart
+++ b/my_solved/lib/views/setting_view.dart
@@ -12,14 +12,31 @@ class SettingView extends StatelessWidget {
       ),
       child: SafeArea(
         child: Container(
-          padding: EdgeInsets.only(top: 10, left: 20),
+          padding: EdgeInsets.only(top: 10, left: 20, right: 20),
           child: Column(
             children: <Widget>[
               Row(
                 children: [
                   Container(
                     padding: EdgeInsets.only(top: 14, bottom: 14),
-                    child: Text('백준 ID'),
+                    child: Text(
+                      '백준 ID',
+                      style: TextStyle(
+                        fontSize: 16,
+                        color: CupertinoTheme.of(context).textTheme.textStyle.color,
+                      ),
+                    ),
+                  ),
+                  Spacer(),
+                  Container(
+                    padding: EdgeInsets.only(top: 14, bottom: 14),
+                    child: Text(
+                      '백준 ID',
+                      style: TextStyle(
+                        fontSize: 16,
+                        color: CupertinoTheme.of(context).textTheme.textStyle.color,
+                      ),
+                    ),
                   ),
                 ],
               ),
@@ -27,7 +44,24 @@ class SettingView extends StatelessWidget {
                 children: [
                   Container(
                     padding: EdgeInsets.only(top: 14, bottom: 14),
-                    child: Text('스트릭 테마'),
+                    child: Text(
+                      '스트릭 테마',
+                      style: TextStyle(
+                        fontSize: 16,
+                        color: CupertinoTheme.of(context).textTheme.textStyle.color,
+                      ),
+                    ),
+                  ),
+                  Spacer(),
+                  Container(
+                    padding: EdgeInsets.only(top: 14, bottom: 14),
+                    child: Text(
+                      '스트릭 테마',
+                      style: TextStyle(
+                        fontSize: 16,
+                        color: CupertinoTheme.of(context).textTheme.textStyle.color,
+                      ),
+                    ),
                   ),
                 ],
               ),
@@ -39,14 +73,20 @@ class SettingView extends StatelessWidget {
                 children: [
                   Container(
                     padding: EdgeInsets.only(top: 14, bottom: 14),
-                    child: Text('라이센스'),
+                    child: Text(
+                      '라이센스',
+                      style: TextStyle(
+                        fontSize: 16,
+                        color: CupertinoTheme.of(context).textTheme.textStyle.color,
+                      ),
+                    ),
                   ),
                   Spacer(),
                   CupertinoButton(
                     onPressed: () {},
                     child: Icon(
                       CupertinoIcons.right_chevron,
-                      color: CupertinoColors.black,
+                      color: CupertinoTheme.of(context).textTheme.textStyle.color,
                     ),
                   )
                 ],

--- a/my_solved/lib/widgets/problem_widget.dart
+++ b/my_solved/lib/widgets/problem_widget.dart
@@ -25,7 +25,10 @@ Widget titleContent(
         width: MediaQuery.of(context).size.width,
         child: Text(
           snapshot.data?.getElementById('problem_title')?.text ?? '',
-          style: TextStyle(fontSize: 17),
+          style: TextStyle(
+              fontSize: 17,
+              color: CupertinoTheme.of(context).textTheme.textStyle.color,
+        ),
         ),
       ),
     ),
@@ -103,6 +106,7 @@ Widget inputContent(
         child: Text(
           snapshot.data?.getElementById('problem_input')?.text ?? '',
           style: TextStyle(
+            color: CupertinoTheme.of(context).textTheme.textStyle.color,
             fontSize: 14,
             fontFamily: 'SourceCodePro',
           ),
@@ -138,7 +142,10 @@ Widget outputContent(
         width: MediaQuery.of(context).size.width,
         child: Text(
           snapshot.data?.getElementById('problem_output')?.text ?? '',
-          style: TextStyle(fontSize: 14),
+          style: TextStyle(
+            color: CupertinoTheme.of(context).textTheme.textStyle.color,
+            fontSize: 14
+          ),
         ),
       ),
     ),
@@ -172,6 +179,7 @@ Widget sampleInputContent(
         child: Text(
           snapshot.data?.getElementById('sample-input-1')?.text ?? '',
           style: TextStyle(
+            color: CupertinoTheme.of(context).textTheme.textStyle.color,
             fontSize: 14,
             fontFamily: 'monospace',
           ),
@@ -208,6 +216,7 @@ Widget sampleOutputContent(
         child: Text(
           snapshot.data?.getElementById('sample-output-1')?.text ?? '',
           style: TextStyle(
+            color: CupertinoTheme.of(context).textTheme.textStyle.color,
             fontSize: 14,
             fontFamily: 'SourceCodePro',
           ),

--- a/my_solved/lib/widgets/user_widget.dart
+++ b/my_solved/lib/widgets/user_widget.dart
@@ -6,7 +6,7 @@ import 'package:flutter_svg/svg.dart';
 import '../models/User.dart';
 import '../models/user/ProblemStats.dart';
 
-Widget backgroundImage(AsyncSnapshot<User> snapshot) {
+Widget backgroundImage(BuildContext context, AsyncSnapshot<User> snapshot) {
   return CupertinoPageScaffold(
     child: ExtendedImage.network(
       snapshot.data?.background['backgroundImageUrl']?? '',
@@ -16,7 +16,7 @@ Widget backgroundImage(AsyncSnapshot<User> snapshot) {
   );
 }
 
-Widget profileImage(AsyncSnapshot<User> snapshot) {
+Widget profileImage(BuildContext context, AsyncSnapshot<User> snapshot) {
   return CupertinoPageScaffold(
     backgroundColor: Colors.transparent,
     child: Card(
@@ -41,7 +41,7 @@ Widget profileImage(AsyncSnapshot<User> snapshot) {
   );
 }
 
-Widget handle(AsyncSnapshot<User> snapshot) {
+Widget handle(BuildContext context, AsyncSnapshot<User> snapshot) {
   return CupertinoPageScaffold(
     backgroundColor: Colors.transparent,
     child: Row(
@@ -50,19 +50,20 @@ Widget handle(AsyncSnapshot<User> snapshot) {
         Text(
           snapshot.data?.handle?? '',
           style: TextStyle(
+            color: CupertinoTheme.of(context).textTheme.textStyle.color,
             fontSize: 30,
             fontWeight: FontWeight.bold,
           ),
         ),
         //badge(snapshot),
-        classes(snapshot),
+        classes(context, snapshot),
       ],
     ),
   );
 }
 
 // 소속
-Widget organizations(AsyncSnapshot<User> snapshot) {
+Widget organizations(BuildContext context, AsyncSnapshot<User> snapshot) {
   return CupertinoPageScaffold(
     backgroundColor: Colors.transparent,
     child: Row(
@@ -91,7 +92,7 @@ Widget organizations(AsyncSnapshot<User> snapshot) {
 }
 
 // 자기소개
-Widget bio(AsyncSnapshot<User> snapshot) {
+Widget bio(BuildContext context, AsyncSnapshot<User> snapshot) {
   return CupertinoPageScaffold(
     backgroundColor: Colors.transparent,
     child: Container(
@@ -104,7 +105,7 @@ Widget bio(AsyncSnapshot<User> snapshot) {
 }
 
 // 클래스
-Widget classes(AsyncSnapshot<User> snapshot) {
+Widget classes(BuildContext context, AsyncSnapshot<User> snapshot) {
   return snapshot.data!.rating >= 3200 ?
   SvgPicture.asset('lib/assets/classes/c10g_.svg', width: 50, height: 50,) :
   SvgPicture.asset(
@@ -115,7 +116,7 @@ Widget classes(AsyncSnapshot<User> snapshot) {
 }
 
 // 티어
-Widget tiers(AsyncSnapshot<User> snapshot) {
+Widget tiers(BuildContext context, AsyncSnapshot<User> snapshot) {
   return CupertinoPageScaffold(
     backgroundColor: Colors.transparent,
     child: Container(
@@ -130,7 +131,7 @@ Widget tiers(AsyncSnapshot<User> snapshot) {
 }
 
 // 레이팅
-Widget rating(AsyncSnapshot<User> snapshot) {
+Widget rating(BuildContext context, AsyncSnapshot<User> snapshot) {
   return CupertinoPageScaffold(
     backgroundColor: Colors.transparent,
     child: Text(
@@ -146,7 +147,7 @@ Widget rating(AsyncSnapshot<User> snapshot) {
 }
 
 // 푼 문제 수
-Widget solvedCount(AsyncSnapshot<User> snapshot) {
+Widget solvedCount(BuildContext context, AsyncSnapshot<User> snapshot) {
   return CupertinoPageScaffold(
     backgroundColor: Colors.transparent,
     child: Container(
@@ -176,7 +177,7 @@ Widget solvedCount(AsyncSnapshot<User> snapshot) {
 }
 
 // 라이벌 수
-Widget reverseRivalCount(AsyncSnapshot<User> snapshot) {
+Widget reverseRivalCount(BuildContext context, AsyncSnapshot<User> snapshot) {
   return CupertinoPageScaffold(
     backgroundColor: Colors.transparent,
     child: Container(
@@ -205,7 +206,7 @@ Widget reverseRivalCount(AsyncSnapshot<User> snapshot) {
 }
 
 // 랭크
-Widget rank(AsyncSnapshot<User> snapshot) {
+Widget rank(BuildContext context, AsyncSnapshot<User> snapshot) {
   return CupertinoPageScaffold(
     backgroundColor: Colors.transparent,
     child: Container(
@@ -270,7 +271,7 @@ Widget zandi(BuildContext context, AsyncSnapshot<User> snapshot) {
 }
 
 // 최대 연속 문제 해결일 수
-Widget maxStreak(AsyncSnapshot<User> snapshot) {
+Widget maxStreak(BuildContext context, AsyncSnapshot<User> snapshot) {
   return CupertinoPageScaffold(
     backgroundColor: Colors.transparent,
     child: Container(
@@ -283,7 +284,7 @@ Widget maxStreak(AsyncSnapshot<User> snapshot) {
 }
 
 // 경험치
-Widget exp(AsyncSnapshot<User> snapshot) {
+Widget exp(BuildContext context, AsyncSnapshot<User> snapshot) {
   return CupertinoPageScaffold(
     backgroundColor: Colors.transparent,
     child: Container(
@@ -296,7 +297,7 @@ Widget exp(AsyncSnapshot<User> snapshot) {
 }
 
 // 배지
-Widget badge(AsyncSnapshot<User> snapshot) {
+Widget badge(BuildContext context, AsyncSnapshot<User> snapshot) {
   return snapshot.data?.badge == null? SizedBox():
     ExtendedImage.network(
       snapshot.data?.badge['badgeImageUrl'],

--- a/my_solved/pubspec.yaml
+++ b/my_solved/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.0+9
+version: 1.0.0+10
 
 environment:
   sdk: '>=2.18.2 <3.0.0'

--- a/my_solved/pubspec.yaml
+++ b/my_solved/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.0+7
+version: 1.0.0+9
 
 environment:
   sdk: '>=2.18.2 <3.0.0'

--- a/my_solved/pubspec.yaml
+++ b/my_solved/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   flutter_svg: ^0.22.0
   cupertino_icons: ^1.0.2
   extended_image: ^6.3.2
+  fluttertoast: ^8.1.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
v1.0.0+10

## 세부 사항
- 로그인 화면에서 아이디 입력하면 홈화면에 반영되도록 함.
  -> providers/user/user_name에서 끌어다 쓸 수 있음. 
- 최초 라우팅이 main_tab에서 login으로 바뀌면서 다크모드 적용이 안되는 이슈가 있었음
  -> 모든 user_widget의 텍스트 색상이 context의 테마를 따르도록 변경
- 안드로이드 sdk 사소한 변경
- 로그인 시 예외처리 추가(실패하면 안넘어감 + 토스트메시지)
- 로그인 이후 로그인 페이지 스택에서 제거
- 조금만 보완하면 출시되겠다!!!!!

<div class="grid-image">
  <img src="https://user-images.githubusercontent.com/52066828/204340498-10c0a199-02f1-4bb6-b6eb-5a22b3485783.png" height="400">
  <img src="https://user-images.githubusercontent.com/52066828/204340540-951cac77-8924-4011-939c-5be77cbf605c.png" 
height="400">
  <img src="https://user-images.githubusercontent.com/52066828/204366894-5f6acbf4-11db-4d1c-8080-a2d927749952.png" 
height="400">
</div>

## 기타 질문 및 특이 사항
 
## 체크 리스트 (아래 사항들이 전부 체크되어야만 merge)
- [x]  필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x]  코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x]  제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x]  본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.
