### PR TITLE
fix: Contest notification text

### DIFF
--- a/my_solved/lib/services/notification_service.dart
+++ b/my_solved/lib/services/notification_service.dart
@@ -164,7 +164,7 @@ class NotificationService extends ChangeNotifier {
         contest.name.hashCode,
         beforeHour + beforeMinute == 0
             ? '대회 시작!'
-            : ('${beforeHour == 0 ? '' : '$beforeHour시간'} ${beforeMinute == 0 ? '$beforeMinute분' : ''} 뒤 대회 시작!'),
+            : ('${beforeHour == 0 ? '' : '$beforeHour시간'} ${beforeMinute == 0 ? '' : '$beforeMinute분'} 뒤 대회 시작!'),
         contest.name,
         startDate,
         details,


### PR DESCRIPTION
## 세부 사항
- [yup0927]: 대회 미리 알림 시간 설정이 0시간 n분일 때 오류
![image](https://user-images.githubusercontent.com/52066828/236494415-9d69e6fc-85d7-46d1-bc84-51480ba2554e.png)


## 기타 질문 및 특이 사항
-
-
 
## 체크 리스트 (아래 사항들이 전부 체크되어야만 merge)
- [x]  필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x]  코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x]  제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x]  본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.
